### PR TITLE
Attributes moved to the class "scope".

### DIFF
--- a/maildocker/message.py
+++ b/maildocker/message.py
@@ -8,14 +8,6 @@ class Mail(object):
 
     """Maildocker Message Class"""
 
-    to = []
-    cc = []
-    bcc = []
-    images = []
-    attachments = []
-    merge_vars = {}
-    mail_from = None
-
     def __init__(self, **opts):
         """
         Constructs Maildocker Message object.
@@ -34,6 +26,13 @@ class Mail(object):
             attachments: Files to attach
             images: Images to attach
         """
+        self.to = []
+        self.cc = []
+        self.bcc = []
+        self.images = []
+        self.attachments = []
+        self.merge_vars = {}
+        
         self.set_from(opts.get('mail_from', ''))
         self.add_to(opts.get('to', []))
         self.add_cc(opts.get('cc', []))


### PR DESCRIPTION
New Maildocker.Mail instances were duplicating some data when sent, example: a new attachment would append new ones to the following recipients, in a sending loop.
